### PR TITLE
Updating to run powershell in non-interactive mode

### DIFF
--- a/src/main/java/hudson/plugins/powershell/PowerShell.java
+++ b/src/main/java/hudson/plugins/powershell/PowerShell.java
@@ -24,7 +24,7 @@ public class PowerShell extends CommandInterpreter {
     }
 
     public String[] buildCommandLine(FilePath script) {
-        return new String[] { "powershell.exe", "-ExecutionPolicy", "ByPass", "& \'" + script.getRemote() + "\'"};
+        return new String[] { "powershell.exe", "-NonInteractive", "-ExecutionPolicy", "ByPass", "& \'" + script.getRemote() + "\'"};
     }
 
     protected String getContents() {


### PR DESCRIPTION
We find that builds will hang from time to time due to issues with powershell scripts that result in a prompt to the user. To avoid hanging scripts when invoking from Jenkins, we should launch powershell in non-interactive mode.