### PR TITLE
use sysnative

### DIFF
--- a/src/main/java/hudson/plugins/powershell/PowerShell.java
+++ b/src/main/java/hudson/plugins/powershell/PowerShell.java
@@ -24,7 +24,7 @@ public class PowerShell extends CommandInterpreter {
     }
 
     public String[] buildCommandLine(FilePath script) {
-        return new String[] { "powershell.exe", "-NonInteractive", "-ExecutionPolicy", "ByPass", "& \'" + script.getRemote() + "\'"};
+        return new String[] { "C:\\Windows\\SysNative\\WindowsPowerShell\\v1.0\\powershell.exe", "-NonInteractive", "-ExecutionPolicy", "ByPass", "& \'" + script.getRemote() + "\'"};
     }
 
     protected String getContents() {


### PR DESCRIPTION
Some commands fail when there is a discrepancy between the bitness of the slave process and the expected command. For example: When your bit32 slave process tries to run the `IIS:` then `dir` commands, you get the error : 

> Retrieving the COM class factory for component with CLSID {688EEEE5-6A7E-422F-B2E1-6AF00DC944A6} failed due to 
> the following error: 80040154 Class not registered (Exception from HRESULT: 0x80040154 (REGDB_E_CLASSNOTREG)).
> At line:1 char:1
> - dir
> - ~~~
>   - CategoryInfo          : NotSpecified: (:) [Get-ChildItem], COMException
>   - FullyQualifiedErrorId : System.Runtime.InteropServices.COMException,Microsoft.PowerShell.Commands.GetChildItemCo 
>     mmand

The fix is to run powershell in `sysnative`. Powershell will use 64bitness when on a 64 bit slave
