### PR TITLE
Support -NoProfile via checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Jenkins PowerShell Plugin
 =========================
 
-Provides Jenkins integration with [Windows PowerShell](http://www.microsoft.com/powershell)
+Provides Jenkins integration with [PowerShell](http://www.microsoft.com/powershell)
 
 See [PowerShell Plugin](https://wiki.jenkins-ci.org/display/JENKINS/PowerShell+Plugin) on the Jenkins Wiki for more information.

--- a/src/main/java/hudson/plugins/powershell/PowerShell.java
+++ b/src/main/java/hudson/plugins/powershell/PowerShell.java
@@ -10,7 +10,7 @@ import org.apache.commons.lang.SystemUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
- * Invokes Windows PowerShell from Jenkins.
+ * Invokes PowerShell from Jenkins.
  * 
  * @author Kohsuke Kawaguchi
  */
@@ -36,17 +36,17 @@ public class PowerShell extends CommandInterpreter {
     public String[] buildCommandLine(FilePath script) {
         if (isRunningOnWindows(script)) {
             if (useProfile){
-                return new String[] { "powershell.exe", "-NonInteractive", "-ExecutionPolicy", "Bypass", "& \'" + script.getRemote() + "\'"};
+                return new String[] { "powershell.exe", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", "\'" + script.getRemote() + "\'"};
             } else {
-                return new String[] { "powershell.exe", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "& \'" + script.getRemote() + "\'"};
+                return new String[] { "powershell.exe", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", "\'" + script.getRemote() + "\'"};
             }
         } else {
             // ExecutionPolicy option does not work (and is not required) for non-Windows platforms
             // See https://github.com/PowerShell/PowerShell/issues/2742
             if (useProfile){
-                return new String[] { "pwsh", "-NonInteractive", "& \'" + script.getRemote() + "\'"};
+                return new String[] { "pwsh", "-NonInteractive", "-File", script.getRemote()};
             } else {
-                return new String[] { "pwsh", "-NonInteractive", "-NoProfile", "& \'" + script.getRemote() + "\'"};
+                return new String[] { "pwsh", "-NonInteractive", "-NoProfile", "-File", script.getRemote()};
             }
         }
     }
@@ -80,7 +80,7 @@ public class PowerShell extends CommandInterpreter {
         }
 
         public String getDisplayName() {
-            return "Windows PowerShell";
+            return "PowerShell";
         }
     }
 }

--- a/src/main/java/hudson/plugins/powershell/PowerShell.java
+++ b/src/main/java/hudson/plugins/powershell/PowerShell.java
@@ -26,7 +26,7 @@ public class PowerShell extends CommandInterpreter {
 
     public String[] buildCommandLine(FilePath script) {
         if (isRunningOnWindows(script)) {
-            return new String[] { "powershell.exe", "-NonInteractive", "-ExecutionPolicy", "Bypass", "& \'" + script.getRemote() + "\'"};
+            return new String[] { "powershell.exe", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "& \'" + script.getRemote() + "\'"};
         } else {
             // ExecutionPolicy option does not work (and is not required) for non-Windows platforms
             // See https://github.com/PowerShell/PowerShell/issues/2742

--- a/src/main/java/hudson/plugins/powershell/PowerShell.java
+++ b/src/main/java/hudson/plugins/powershell/PowerShell.java
@@ -15,8 +15,17 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * @author Kohsuke Kawaguchi
  */
 public class PowerShell extends CommandInterpreter {
+    
+    /** boolean switch setting -NoProfile */
+    public boolean useProfile;
+    
+    /**
+    * @param command 
+    * @param useProfile whether to use profile or set -NoProfile
+    */
     @DataBoundConstructor
-    public PowerShell(String command) {
+    public PowerShell(String command, boolean useProfile) {
+        this.useProfile = useProfile;
         super(command);
     }
 
@@ -26,7 +35,11 @@ public class PowerShell extends CommandInterpreter {
 
     public String[] buildCommandLine(FilePath script) {
         if (isRunningOnWindows(script)) {
-            return new String[] { "powershell.exe", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "& \'" + script.getRemote() + "\'"};
+            if (useProfile){
+                return new String[] { "powershell.exe", "-NonInteractive", "-ExecutionPolicy", "Bypass", "& \'" + script.getRemote() + "\'"};
+            } else {
+                return new String[] { "powershell.exe", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "& \'" + script.getRemote() + "\'"};
+            }
         } else {
             // ExecutionPolicy option does not work (and is not required) for non-Windows platforms
             // See https://github.com/PowerShell/PowerShell/issues/2742

--- a/src/main/java/hudson/plugins/powershell/PowerShell.java
+++ b/src/main/java/hudson/plugins/powershell/PowerShell.java
@@ -43,7 +43,11 @@ public class PowerShell extends CommandInterpreter {
         } else {
             // ExecutionPolicy option does not work (and is not required) for non-Windows platforms
             // See https://github.com/PowerShell/PowerShell/issues/2742
-            return new String[] { "pwsh", "-NonInteractive", "& \'" + script.getRemote() + "\'"};
+            if (useProfile){
+                return new String[] { "pwsh", "-NonInteractive", "& \'" + script.getRemote() + "\'"};
+            } else {
+                return new String[] { "pwsh", "-NonInteractive", "-NoProfile", "& \'" + script.getRemote() + "\'"};
+            }
         }
     }
 

--- a/src/main/java/hudson/plugins/powershell/PowerShell.java
+++ b/src/main/java/hudson/plugins/powershell/PowerShell.java
@@ -25,8 +25,8 @@ public class PowerShell extends CommandInterpreter {
     */
     @DataBoundConstructor
     public PowerShell(String command, boolean useProfile) {
-        this.useProfile = useProfile;
         super(command);
+        this.useProfile = useProfile;
     }
 
     protected String getFileExtension() {

--- a/src/main/java/hudson/plugins/powershell/PowerShell.java
+++ b/src/main/java/hudson/plugins/powershell/PowerShell.java
@@ -36,9 +36,9 @@ public class PowerShell extends CommandInterpreter {
     public String[] buildCommandLine(FilePath script) {
         if (isRunningOnWindows(script)) {
             if (useProfile){
-                return new String[] { "powershell.exe", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", "\'" + script.getRemote() + "\'"};
+                return new String[] { "powershell.exe", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", script.getRemote()};
             } else {
-                return new String[] { "powershell.exe", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", "\'" + script.getRemote() + "\'"};
+                return new String[] { "powershell.exe", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", script.getRemote()};
             }
         } else {
             // ExecutionPolicy option does not work (and is not required) for non-Windows platforms

--- a/src/main/resources/hudson/plugins/powershell/PowerShell/config.jelly
+++ b/src/main/resources/hudson/plugins/powershell/PowerShell/config.jelly
@@ -26,4 +26,7 @@ THE SOFTWARE.
   <f:entry title="${%Command}" description="${%description(rootURL)}">
     <f:textarea name="command" value="${instance.command}" class="fixed-width" />
   </f:entry>
+   <f:entry field="useProfile" title="">
+    <f:checkbox title="${%Use PowerShell profile}" default="true" />
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
 <div>
-  This plugin allows Jenkins to invoke <a href="http://en.wikipedia.org/wiki/Windows_PowerShell">Windows PowerShell</a> as build scripts.
+  This plugin allows Jenkins to invoke <a href="http://en.wikipedia.org/wiki/Windows_PowerShell">PowerShell</a> as build scripts.
+  It uses PowerShell.exe on Windows and pwsh on Linux.
 </div>

--- a/src/main/webapp/env-vars.html
+++ b/src/main/webapp/env-vars.html
@@ -6,7 +6,7 @@
 	</style>
 </head>
 <body>
-	The following variables are available to Windows PowerShell scripts
+	The following variables are available to PowerShell scripts
 	
 	<dl>
 		<dt>$ENV:BUILD_NUMBER</dt>

--- a/src/main/webapp/env-vars_fr.html
+++ b/src/main/webapp/env-vars_fr.html
@@ -6,7 +6,7 @@
 	</style>
 </head>
 <body>
-	Les variables suivantes sont mises à disposition de Windows PowerShell
+	Les variables suivantes sont mises à disposition de PowerShell
 	
 	<dl>
 		<dt>$ENV:BUILD_NUMBER</dt>

--- a/src/main/webapp/help.html
+++ b/src/main/webapp/help.html
@@ -5,7 +5,8 @@
   The text you enter in the text box will be executed as a PowerShell file, and a build
   will be considered a failure if at the end of the execution $LastExitCode is not 0.
 
-  By default PowerShell uses profile(s) which can be disabled to avoid any potential conflict and provide a clean shell.
+  By default, PowerShell processes profiles scripts at startup. 
+  This can be disabled to improve startup time, avoid any potential conflict and provide a clean shell.
   
   <p>
     If you already have a batch file in SCM, you can just type in the path of that PowerShell file

--- a/src/main/webapp/help.html
+++ b/src/main/webapp/help.html
@@ -1,12 +1,14 @@
 <div>
-  Runs a Windows PowerShell script for building the project.
+  Runs a PowerShell script for building the project.
   The script will be run with the workspace as the current directory.
   
   The text you enter in the text box will be executed as a PowerShell file, and a build
   will be considered a failure if at the end of the execution $LastExitCode is not 0.
 
-  By default, PowerShell processes profiles scripts at startup. 
+  By default, PowerShell processes profile scripts at startup. 
   This can be disabled to improve startup time, avoid any potential conflict and provide a clean shell.
+
+  On Windows it uses PowerShell.exe and on Linux pwsh (PowerShell Core)
   
   <p>
     If you already have a batch file in SCM, you can just type in the path of that PowerShell file

--- a/src/main/webapp/help.html
+++ b/src/main/webapp/help.html
@@ -4,6 +4,8 @@
   
   The text you enter in the text box will be executed as a PowerShell file, and a build
   will be considered a failure if at the end of the execution $LastExitCode is not 0.
+
+  By default PowerShell uses profile(s) which can be disabled to avoid any potential conflict and provide a clean shell.
   
   <p>
     If you already have a batch file in SCM, you can just type in the path of that PowerShell file

--- a/src/main/webapp/help_fr.html
+++ b/src/main/webapp/help_fr.html
@@ -1,5 +1,5 @@
 ﻿<div>
-  Lance un script Windows PowerShell pour construire le projet.
+  Lance un script PowerShell pour construire le projet.
   Le script sera lancé avec le répertoire workspace comme répertoire de
   travail.
   

--- a/src/test/java/hudson/plugins/powershell/PowerShellTest.java
+++ b/src/test/java/hudson/plugins/powershell/PowerShellTest.java
@@ -9,7 +9,7 @@ import hudson.model.FreeStyleProject;
 public class PowerShellTest extends HudsonTestCase {
     public void testConfigRoundtrip() throws Exception {
         FreeStyleProject p = createFreeStyleProject();
-        PowerShell orig = new PowerShell("script");
+        PowerShell orig = new PowerShell("script", true);
         p.getBuildersList().add(orig);
         submit(new WebClient().getPage(p,"configure").getFormByName("config"));
 


### PR DESCRIPTION
[Updating the PR description to reflect all the changes]

This change will add an option for PowerShell via a checkbox to use the -NoProfile switch when executing.
The rationale behind this change is to allow PowerShell executing without any profile in a clean shell.

Currently this is not possible so many of us needing -NoProfile have to use windows batch to start powershell with -NoProfile ( or pwsh from bash).

Additionally, based on comments on this PR these have also been changed
* support -NoProfile for both Windows PowerShell.exe and Linux pwsh
* changed to -File instead of the implied -Command "& script.ps1" version as it returns the proper exit code
* removed quoting of the -File parameter as it caused Jenkins failure on Windows - this might need more follow-up
* Since the plugin now supports both Windows and Linux I've renamed "Windows PowerShell" to just "PowerShell" to reflect that it's now cross platform => Does it have a potential of breaking something ? as if yes, I would undo that part.

I've built and tested the plugin locally on both Windows and Linux agents and confirmed that it worked.

Maintainers: I would recommend taking the offer from @rkeithhill who is a well known [PowerShell OSS](https://github.com/Pscx/Pscx) [contributor](https://stackoverflow.com/users/153982/keith-hill) and [book author](https://rkeithhill.wordpress.com/2009/03/08/effective-windows-powershell-the-free-ebook/)


>Not that I need another OSS project to work on, I currently work on posh-git, Plaster, vscode-powershell and PowerShellEditorServices but ... do you guys need help maintaining this repo? We rely on this plugin heavily where I work so I'm motivated to keep it updated and of high quality. But I'd need a little help on what is required to build, deploy and test it locally.

Keith: this is how you test it:
* spin up locally 
` java -jar jenkins.war --httpPort=5555`
* or just build the plugin
`mvn package`
* then upload the target/powershell.hpi to your test instance http://$jenkins:port/pluginManager/advanced