### PR TITLE
Rename PowerShell binary on Linux/macOS to pwsh

### DIFF
--- a/src/main/java/hudson/plugins/powershell/PowerShell.java
+++ b/src/main/java/hudson/plugins/powershell/PowerShell.java
@@ -30,7 +30,7 @@ public class PowerShell extends CommandInterpreter {
         } else {
             // ExecutionPolicy option does not work (and is not required) for non-Windows platforms
             // See https://github.com/PowerShell/PowerShell/issues/2742
-            return new String[] { "powershell", "-NonInteractive", "& \'" + script.getRemote() + "\'"};
+            return new String[] { "pwsh", "-NonInteractive", "& \'" + script.getRemote() + "\'"};
         }
     }
 


### PR DESCRIPTION
Several months back the PowerShell team renamed the binary for PowerShell Core to `pwsh` on Linux and macOS and `pwsh.exe` on Windows.  I believe when running on Windows systems, we want to continue to use Windows PowerShell (powershell.exe) as the default.  However if there was a way the user could choose between pwsh.exe and powershell.exe on Windows, that would be really useful.  Neither is a full superset of the other - each has unique functionality.

We should also consider renaming the plugin from `Windows PowerShell` to just `PowerShell`.  See https://blogs.msdn.microsoft.com/powershell/2017/07/14/powershell-6-0-roadmap-coreclr-backwards-compatibility-and-more/ for more info on PowerShell editions.