### PR TITLE
Change launch commands to use -file instead of "command"

### DIFF
--- a/src/main/java/hudson/plugins/powershell/PowerShell.java
+++ b/src/main/java/hudson/plugins/powershell/PowerShell.java
@@ -26,11 +26,11 @@ public class PowerShell extends CommandInterpreter {
 
     public String[] buildCommandLine(FilePath script) {
         if (isRunningOnWindows(script)) {
-            return new String[] { "powershell.exe", "-NonInteractive", "-ExecutionPolicy", "Bypass", "& \'" + script.getRemote() + "\'"};
+            return new String[] { "powershell.exe", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File" , script.getRemote()};
         } else {
             // ExecutionPolicy option does not work (and is not required) for non-Windows platforms
             // See https://github.com/PowerShell/PowerShell/issues/2742
-            return new String[] { "pwsh", "-NonInteractive", "& \'" + script.getRemote() + "\'"};
+            return new String[] { "pwsh", "-NonInteractive", "-File" , script.getRemote()};
         }
     }
 


### PR DESCRIPTION
As the complete PowerShell value is provided as a Script, It is better to use the option -file instead of the command (not by default for linux). 