### PR TITLE
Adds support for defining the PowerShell version to be used

### DIFF
--- a/src/main/java/hudson/plugins/powershell/PowerShell.java
+++ b/src/main/java/hudson/plugins/powershell/PowerShell.java
@@ -23,12 +23,20 @@ public class PowerShell extends CommandInterpreter {
     
     private final String powerShellVersionPreference;
 
+    @Deprecated
+    public PowerShell(String command, boolean stopOnError, boolean useProfile) {
+        super(command);
+        this.stopOnError = stopOnError;
+        this.useProfile = useProfile;
+        this.powerShellVersionPreference = "osBased";
+    }
+
     @DataBoundConstructor
     public PowerShell(String command, boolean stopOnError, boolean useProfile, String powerShellVersionPreference) {
         super(command);
         this.stopOnError = stopOnError;
         this.useProfile = useProfile;
-        this.powerShellVersionPreference = powerShellVersionPreference == null ? "osBased" : powerShellVersionPreference;
+        this.powerShellVersionPreference = powerShellVersionPreference;
     }
 
     public boolean isStopOnError() {
@@ -42,15 +50,13 @@ public class PowerShell extends CommandInterpreter {
     public String getPowerShellVersionPreference() {
         return powerShellVersionPreference;
     }
-    
+
     protected String getFileExtension() {
         return ".ps1";
     }
 
     public String[] buildCommandLine(FilePath script) {
-        System.out.println(powerShellVersionPreference);
-
-        switch (powerShellVersionPreference) {
+        switch (powerShellVersionPreference == null ? "osBased" : powerShellVersionPreference) {
             case "windowsPowerShell":
                 if (useProfile) {
                     return new String[]{"powershell.exe", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", script.getRemote()};

--- a/src/main/resources/hudson/plugins/powershell/PowerShell/config.jelly
+++ b/src/main/resources/hudson/plugins/powershell/PowerShell/config.jelly
@@ -37,4 +37,11 @@ THE SOFTWARE.
     <f:checkbox title="${%Use PowerShell profile}" default="true" />
   </f:entry>
 
+    <f:entry title="PowerShell Version Preference" field="powerShellVersionPreference">
+        <select name="powerShellVersionPreference">
+            <f:option value="osBased" selected="${instance.powerShellVersionPreference == 'osBased'}">OS Based</f:option>
+            <f:option value="windowsPowerShell" selected="${instance.powerShellVersionPreference == 'windowsPowerShell'}">Windows PowerShell</f:option>
+            <f:option value="powershellCore" selected="${instance.powerShellVersionPreference == 'powershellCore'}">PowerShell Core</f:option>  
+        </select>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/powershell/PowerShell/help-powerShellVersionPreference.html
+++ b/src/main/resources/hudson/plugins/powershell/PowerShell/help-powerShellVersionPreference.html
@@ -1,0 +1,3 @@
+<div>
+    <p>Indicates which version of PowerShell to use. PowerShell Core will use pwsh and Windows PowerShell will use powershell.</p>
+</div>


### PR DESCRIPTION
This adds the ability to force the plugin to use Windows PowerShell or PowerShell core. The default value is the current method of determining which version to use.

Reference: https://issues.jenkins-ci.org/browse/JENKINS-52421