### PR TITLE
Make the ErrorActionPreference selection optional

### DIFF
--- a/src/main/java/hudson/plugins/powershell/PowerShell.java
+++ b/src/main/java/hudson/plugins/powershell/PowerShell.java
@@ -129,10 +129,13 @@ public class PowerShell extends CommandInterpreter {
         switch (errorAction) {
             case "stopOnError":
                 sb.append("$ErrorActionPreference=\"Stop\"");
+                break;
             case "continueOnError":
                 sb.append("$ErrorActionPreference=\"Continue\"");
+                break;
             default:
                 sb.append("#No override to ErrorActionPreference selected");
+                break;
         }
         sb.append(System.lineSeparator());
         sb.append(command);

--- a/src/main/java/hudson/plugins/powershell/PowerShell.java
+++ b/src/main/java/hudson/plugins/powershell/PowerShell.java
@@ -27,14 +27,14 @@ public class PowerShell extends CommandInterpreter {
 
     private Integer unstableReturn;
 
-    private final boolean stopOnError;
+    private String errorAction;
 
     private transient TaskListener listener;
 
     @DataBoundConstructor
-    public PowerShell(String command, boolean stopOnError, boolean useProfile, Integer unstableReturn) {
+    public PowerShell(String command, String errorAction, boolean useProfile, Integer unstableReturn) {
         super(command);
-        this.stopOnError = stopOnError;
+        this.errorAction = errorAction;
         this.useProfile = useProfile;
         this.unstableReturn = unstableReturn;
     }
@@ -51,10 +51,6 @@ public class PowerShell extends CommandInterpreter {
         {
             throw e;
         }
-    }
-
-    public boolean isStopOnError() {
-        return stopOnError;
     }
 
     public boolean isUseProfile() {
@@ -130,10 +126,13 @@ public class PowerShell extends CommandInterpreter {
     @Override
     protected String getContents() {
         StringBuilder sb = new StringBuilder();
-        if (stopOnError) {
-            sb.append("$ErrorActionPreference=\"Stop\"");
-        } else {
-            sb.append("$ErrorActionPreference=\"Continue\"");
+        switch (errorAction) {
+            case "stopOnError":
+                sb.append("$ErrorActionPreference=\"Stop\"");
+            case "continueOnError":
+                sb.append("$ErrorActionPreference=\"Continue\"");
+            default:
+                sb.append("#No override to ErrorActionPreference selected");
         }
         sb.append(System.lineSeparator());
         sb.append(command);

--- a/src/main/resources/hudson/plugins/powershell/PowerShell/config.jelly
+++ b/src/main/resources/hudson/plugins/powershell/PowerShell/config.jelly
@@ -29,9 +29,13 @@ THE SOFTWARE.
     codemirror-config="mode: 'text/x-groovy', lineNumbers: true, matchBrackets: true, onBlur: function(editor){editor.save()}"/>
  </f:entry>
 
-  <f:entry field="stopOnError" title="Stop On Errors">
-       <f:checkbox name="stopOnError" checked="${instance.stopOnError}" default="true" />
-  </f:entry>
+  <f:entry field="errorAction" title="Override Error Action">
+    <select name="errorAction">
+        <option value="noOverride">No Override</option>
+        <option value="stopOnError">Stop on Error</option>
+        <option value="continueOnError">Continue on Error</option>
+    </select>
+</f:entry>
 
    <f:entry field="useProfile" title="${%Use PowerShell profile}">
     <f:checkbox default="true" />

--- a/src/main/resources/hudson/plugins/powershell/PowerShell/help-errorAction.html
+++ b/src/main/resources/hudson/plugins/powershell/PowerShell/help-errorAction.html
@@ -1,0 +1,6 @@
+<div>
+    <p>Provides an option to override the system's default ErrorActionPreference. "Stop on Error" stops the script when any step fails (similar to Shell set -e). "Continue on Error" writes the error to the console, but does not stop the script. If selected, this inserts `$ErrorActionPreference=Stop` or `$ErrorActionPreference=Continue` to the beginning of the script. As such, these options do not allow for a param() block at the beginning of your script.
+        <br />
+        <br />See <a href="https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-6#erroractionpreference">documentation</a>.
+    </p>
+</div>

--- a/src/main/resources/hudson/plugins/powershell/PowerShell/help-stopOnError.html
+++ b/src/main/resources/hudson/plugins/powershell/PowerShell/help-stopOnError.html
@@ -1,3 +1,0 @@
-<div>
-    <p>Stops script when some step fails. Similar to Shell set -e. Translates to $ErrorActionPreference Stop or Continue. See <a href="https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-6#erroractionpreference">documentation</a>.</p>
-</div>

--- a/src/test/java/hudson/plugins/powershell/PowerShellTest.java
+++ b/src/test/java/hudson/plugins/powershell/PowerShellTest.java
@@ -28,7 +28,7 @@ public class PowerShellTest {
     @Test
     public void testConfigRoundtrip() throws Exception {
         FreeStyleProject p = r.createFreeStyleProject();
-        PowerShell orig = new PowerShell("script", true, true, null);
+        PowerShell orig = new PowerShell("script", "noOverride", true, null);
         p.getBuildersList().add(orig);
 
         JenkinsRule.WebClient webClient = r.createWebClient();
@@ -44,7 +44,7 @@ public class PowerShellTest {
         Assume.assumeTrue(isPowerShellAvailable());
 
         FreeStyleProject project1 = r.createFreeStyleProject("project1");
-        project1.getBuildersList().add(new PowerShell("echo 'Hello World!'", true, true, null));
+        project1.getBuildersList().add(new PowerShell("echo 'Hello World!'", "noOverride", true, null));
 
         QueueTaskFuture<FreeStyleBuild> freeStyleBuildQueueTaskFuture = project1.scheduleBuild2(0);
         FreeStyleBuild build = freeStyleBuildQueueTaskFuture.get();
@@ -56,7 +56,7 @@ public class PowerShellTest {
     public void testBuildBadCommandFails() throws Exception {
         Assume.assumeTrue(isPowerShellAvailable());
         FreeStyleProject project1 = r.createFreeStyleProject("project1");
-        project1.getBuildersList().add(new PowerShell("wrong command", true, true, null));
+        project1.getBuildersList().add(new PowerShell("wrong command", "noOverride", true, null));
 
         QueueTaskFuture<FreeStyleBuild> freeStyleBuildQueueTaskFuture = project1.scheduleBuild2(0);
         FreeStyleBuild build = freeStyleBuildQueueTaskFuture.get();
@@ -68,7 +68,7 @@ public class PowerShellTest {
     public void testBuildBadCommandsSucceeds() throws Exception {
         Assume.assumeTrue(isPowerShellAvailable());
         FreeStyleProject project1 = r.createFreeStyleProject("project1");
-        project1.getBuildersList().add(new PowerShell("wrong command", false, true, null));
+        project1.getBuildersList().add(new PowerShell("wrong command", "noOverride", true, null));
 
         QueueTaskFuture<FreeStyleBuild> freeStyleBuildQueueTaskFuture = project1.scheduleBuild2(0);
         FreeStyleBuild build = freeStyleBuildQueueTaskFuture.get();
@@ -81,7 +81,7 @@ public class PowerShellTest {
         Assume.assumeTrue(isPowerShellAvailable());
 
         FreeStyleProject project1 = r.createFreeStyleProject("project1");
-        project1.getBuildersList().add(new PowerShell("echo 'Hello World!'", true, true, null));
+        project1.getBuildersList().add(new PowerShell("echo 'Hello World!'", "noOverride", true, null));
 
         QueueTaskFuture<FreeStyleBuild> freeStyleBuildQueueTaskFuture = project1.scheduleBuild2(0);
         FreeStyleBuild build = freeStyleBuildQueueTaskFuture.get();
@@ -95,7 +95,7 @@ public class PowerShellTest {
     public void testBuildUnstableEnabledSucceeds() throws Exception {
         Assume.assumeTrue(isPowerShellAvailable());
         FreeStyleProject project1 = r.createFreeStyleProject("project1");
-        project1.getBuildersList().add(new PowerShell("exit 0", true, true, 123));
+        project1.getBuildersList().add(new PowerShell("exit 0", "noOverride", true, 123));
 
         QueueTaskFuture<FreeStyleBuild> freeStyleBuildQueueTaskFuture = project1.scheduleBuild2(0);
         FreeStyleBuild build = freeStyleBuildQueueTaskFuture.get();
@@ -107,7 +107,7 @@ public class PowerShellTest {
     public void testBuildUnstableEnabledBadCommandFails() throws Exception {
         Assume.assumeTrue(isPowerShellAvailable());
         FreeStyleProject project1 = r.createFreeStyleProject("project1");
-        project1.getBuildersList().add(new PowerShell("exit 1", true, true, 123));
+        project1.getBuildersList().add(new PowerShell("exit 1", "noOverride", true, 123));
 
         QueueTaskFuture<FreeStyleBuild> freeStyleBuildQueueTaskFuture = project1.scheduleBuild2(0);
         FreeStyleBuild build = freeStyleBuildQueueTaskFuture.get();
@@ -119,7 +119,7 @@ public class PowerShellTest {
     public void testBuildUnstableEnabledBadCommandUnstableErrorCode() throws Exception {
         Assume.assumeTrue(isPowerShellAvailable());
         FreeStyleProject project1 = r.createFreeStyleProject("project1");
-        project1.getBuildersList().add(new PowerShell("exit 123", true, true, 123));
+        project1.getBuildersList().add(new PowerShell("exit 123", "noOverride", true, 123));
 
         QueueTaskFuture<FreeStyleBuild> freeStyleBuildQueueTaskFuture = project1.scheduleBuild2(0);
         FreeStyleBuild build = freeStyleBuildQueueTaskFuture.get();


### PR DESCRIPTION
This changes the "stopOnError" checkbox to a select, offering an option to *not* override the ErrorActionPreference for a script. This is to address situations where Powershell scripts include param() blocks, which causes a script to fail if there are any commands preceding them in a script.

https://issues.jenkins.io/browse/JENKINS-60423
