### PR TITLE
fix: JENKINS-66701 using $OutputEncoding

### DIFF
--- a/src/main/java/hudson/plugins/powershell/PowerShell.java
+++ b/src/main/java/hudson/plugins/powershell/PowerShell.java
@@ -105,8 +105,7 @@ public class PowerShell extends CommandInterpreter {
                 e.printStackTrace();
             }
         }
-        if (powerShellExecutable == null)
-        {
+        if (powerShellExecutable == null) {
             powerShellExecutable = PowerShellInstallation.getDefaultPowershellWhenNoConfiguration(isRunningOnWindows(script));
         }
 
@@ -130,6 +129,8 @@ public class PowerShell extends CommandInterpreter {
     @Override
     protected String getContents() {
         StringBuilder sb = new StringBuilder();
+        sb.append("$OutputEncoding = [Console]::InputEncoding = [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding");
+        sb.append(System.lineSeparator());
         if (stopOnError) {
             sb.append("$ErrorActionPreference=\"Stop\"");
         } else {
@@ -167,8 +168,7 @@ public class PowerShell extends CommandInterpreter {
     @Extension
     public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
 
-        public DescriptorImpl()
-        {
+        public DescriptorImpl() {
             super();
             load();
         }

--- a/src/test/java/hudson/plugins/powershell/PowerShellTest.java
+++ b/src/test/java/hudson/plugins/powershell/PowerShellTest.java
@@ -142,6 +142,7 @@ public class PowerShellTest {
 
     @Test
     public void testBuildEncodingOnWindowsWithPowerShellCore() throws Exception {
+        Assume.assumeTrue(isPowerShellAvailable());
         Computer computer = r.jenkins.getComputer("");
         Assume.assumeTrue(Boolean.FALSE.equals(computer.isUnix()));
 
@@ -166,6 +167,7 @@ public class PowerShellTest {
 
     @Test
     public void testBuildEncodingOnWindowsWithBatch() throws Exception {
+        Assume.assumeTrue(isPowerShellAvailable());
         Computer computer = r.jenkins.getComputer("");
         Assume.assumeTrue(Boolean.FALSE.equals(computer.isUnix()));
 

--- a/src/test/java/hudson/plugins/powershell/PowerShellTest.java
+++ b/src/test/java/hudson/plugins/powershell/PowerShellTest.java
@@ -8,10 +8,13 @@ import java.util.stream.Stream;
 
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import hudson.model.Computer;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
 import hudson.model.queue.QueueTaskFuture;
+import hudson.tasks.BatchFile;
+import hudson.tools.ToolLocationNodeProperty;
 import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
@@ -135,5 +138,45 @@ public class PowerShellTest {
                                 Files.exists(path.resolve("pwsh.exe")) ||
                                 Files.exists(path.resolve("powershell")) ||
                                 Files.exists(path.resolve("powershell.exe")));
+    }
+
+    @Test
+    public void testBuildEncodingOnWindowsWithPowerShellCore() throws Exception {
+        Computer computer = r.jenkins.getComputer("");
+        Assume.assumeTrue(Boolean.FALSE.equals(computer.isUnix()));
+
+        PowerShellInstallation.DescriptorImpl descriptor =
+                r.jenkins.getDescriptorByType(PowerShellInstallation.DescriptorImpl.class);
+        ToolLocationNodeProperty.ToolLocation toolLocation
+                = new ToolLocationNodeProperty.ToolLocation(descriptor,
+                "DefaultWindows",
+                "C:\\Program Files\\PowerShell\\7\\pwsh.exe");
+        ToolLocationNodeProperty toolLocationNodeProperty = new ToolLocationNodeProperty(toolLocation);
+        computer.getNode().getNodeProperties().add(toolLocationNodeProperty);
+
+        FreeStyleProject project1 = r.createFreeStyleProject("project1");
+        project1.getBuildersList().add(new PowerShell("Write-Host \"UTF-8 Sign: ✅\"", true, false, 123));
+
+        QueueTaskFuture<FreeStyleBuild> freeStyleBuildQueueTaskFuture = project1.scheduleBuild2(0);
+        FreeStyleBuild build = freeStyleBuildQueueTaskFuture.get();
+
+        r.assertLogContains("UTF-8 Sign: ✅", build);
+        r.assertBuildStatusSuccess(build);
+    }
+
+    @Test
+    public void testBuildEncodingOnWindowsWithBatch() throws Exception {
+        Computer computer = r.jenkins.getComputer("");
+        Assume.assumeTrue(Boolean.FALSE.equals(computer.isUnix()));
+
+        FreeStyleProject project1 = r.createFreeStyleProject("project1");
+        project1.getBuildersList()
+                .add(new BatchFile("pwsh.exe -NonInteractive -ExecutionPolicy Bypass -Command \"Write-Host UTF-8 Sign: ✅\""));
+
+        QueueTaskFuture<FreeStyleBuild> freeStyleBuildQueueTaskFuture = project1.scheduleBuild2(0);
+        FreeStyleBuild build = freeStyleBuildQueueTaskFuture.get();
+
+        r.assertLogContains("UTF-8 Sign: ✅", build);
+        r.assertBuildStatusSuccess(build);
     }
 }


### PR DESCRIPTION
This sets the $OutputEncoding and the Console Input/Output Encoding to UTF-8 prior to running the rest of the generated script. Maybe it should be an option? I would be happy to implement it that way if desired.

https://issues.jenkins.io/browse/JENKINS-66701

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
