### PR TITLE
Use HTTPS instead of git

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,9 +32,9 @@
   </developers>
   
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <connection>scm:git:https://github.com/jenkinsci/powershell-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/powershell-plugin.git</developerConnection>
+    <url>http://github.com/jenkinsci/powershell-plugin</url>
     <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION
Use HTTPS protocol instead of git protocol because Github is deprecating git protocol

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] ~~Link to relevant issues in GitHub or Jira~~
- [x] ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [x] ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~

