### PR TITLE
Replace JSR-305 annotations with spotbugs annotations

### DIFF
--- a/src/main/java/hudson/plugins/powershell/PowerShell.java
+++ b/src/main/java/hudson/plugins/powershell/PowerShell.java
@@ -8,7 +8,7 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.tasks.CommandInterpreter;
 import jenkins.model.Jenkins;
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import org.apache.commons.lang.SystemUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;

--- a/src/main/java/hudson/plugins/powershell/PowerShellInstallation.java
+++ b/src/main/java/hudson/plugins/powershell/PowerShellInstallation.java
@@ -1,5 +1,6 @@
 package hudson.plugins.powershell;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -20,7 +21,6 @@ import org.kohsuke.stapler.StaplerRequest;
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.util.List;
-import javax.annotation.Nonnull;
 
 public class PowerShellInstallation extends ToolInstallation implements NodeSpecific<PowerShellInstallation>,
         EnvironmentSpecific<PowerShellInstallation> {
@@ -38,7 +38,7 @@ public class PowerShellInstallation extends ToolInstallation implements NodeSpec
     }
 
     @Override
-    public PowerShellInstallation forNode(@Nonnull Node node, TaskListener log) throws IOException, InterruptedException {
+    public PowerShellInstallation forNode(@NonNull Node node, TaskListener log) throws IOException, InterruptedException {
         return new PowerShellInstallation(getName(), translateFor(node, log), getProperties());
     }
 
@@ -85,7 +85,7 @@ public class PowerShellInstallation extends ToolInstallation implements NodeSpec
         }
 
         @Override
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return "PowerShell";
         }


### PR DESCRIPTION
## Replace JSR-305 annotations with spotbugs annotations

Annotations for Nonnull, CheckForNull, and several others were proposed for Java as part of dormant Java specification request JSR-305. The proposal never became a part of standard Java.

Jenkins plugins should switch from using JSR-305 annotations to use Spotbugs annotations that provide the same semantics.

The [mailing list discussion](https://groups.google.com/g/jenkinsci-dev/c/uE1wwtVi1W0/m/gLxdEJmlBQAJ) from James Nord describes the affected annotations and why they should be replaced with annotations that are actively maintained.

The ["Improve a plugin" tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/) provides instructions to perform this change.

An [OpenRewrite recipe](https://docs.openrewrite.org/recipes/jenkins/javaxannotationstospotbugs) is also available and is even better than the tutorial.

### Testing done

Confirmed that automated tests pass on Linux with Java 21.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
